### PR TITLE
Support to analyze HTML tags attributes (ids & classes).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bin/
 vendor/*/
+testdata/actual/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "testdata/case/src/github.com/sgtest/css-sample-0"]
+	path = testdata/case/src/github.com/sgtest/css-sample-0
+	url = https://github.com/sgtest/css-sample-0.git

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ default: govendor install
 install: ${EXE}
 
 clean:
-	rm ${EXE}
+	rm -f ${EXE}
 
 govendor:
 	go get github.com/kardianos/govendor

--- a/Srclibtoolchain
+++ b/Srclibtoolchain
@@ -4,14 +4,14 @@
       "Subcmd": "scan",
       "Op": "scan",
       "SourceUnitTypes": [
-        "Dir"
+        "basic-css"
       ]
     },
     {
       "Subcmd": "graph",
       "Op": "graph",
       "SourceUnitTypes": [
-        "Dir"
+        "basic-css"
       ]
     }
   ],

--- a/css_def/def.go
+++ b/css_def/def.go
@@ -1,0 +1,48 @@
+package css_def
+
+import (
+	"encoding/json"
+
+	"sourcegraph.com/sourcegraph/srclib/graph"
+)
+
+func init() {
+	graph.RegisterMakeDefFormatter("Dir", newDefFormatter)
+}
+
+// DefData should be kept in sync with the def 'Data' field emitted by the
+// basic grapher.
+type DefData struct {
+	Name      string
+	Keyword   string
+	Type      string
+	Kind      string
+	Separator string
+}
+
+func newDefFormatter(s *graph.Def) graph.DefFormatter {
+	var si DefData
+	if len(s.Data) > 0 {
+		if err := json.Unmarshal(s.Data, &si); err != nil {
+			panic("unmarshal CSS def data: " + err.Error())
+		}
+	}
+	return defFormatter{s, &si}
+}
+
+type defFormatter struct {
+	def  *graph.Def
+	data *DefData
+}
+
+func (f defFormatter) Language() string { return "CSS" }
+
+func (f defFormatter) DefKeyword() string { return f.data.Keyword }
+
+func (f defFormatter) Kind() string { return f.data.Kind }
+
+func (f defFormatter) NameAndTypeSeparator() string { return f.data.Separator }
+
+func (f defFormatter) Type(qual graph.Qualification) string { return f.data.Type }
+
+func (f defFormatter) Name(qual graph.Qualification) string { return f.def.Name }

--- a/css_def/def.go
+++ b/css_def/def.go
@@ -1,15 +1,5 @@
 package css_def
 
-import (
-	"encoding/json"
-
-	"sourcegraph.com/sourcegraph/srclib/graph"
-)
-
-func init() {
-	graph.RegisterMakeDefFormatter("Dir", newDefFormatter)
-}
-
 // DefData should be kept in sync with the def 'Data' field emitted by the
 // basic grapher.
 type DefData struct {
@@ -19,30 +9,3 @@ type DefData struct {
 	Kind      string
 	Separator string
 }
-
-func newDefFormatter(s *graph.Def) graph.DefFormatter {
-	var si DefData
-	if len(s.Data) > 0 {
-		if err := json.Unmarshal(s.Data, &si); err != nil {
-			panic("unmarshal CSS def data: " + err.Error())
-		}
-	}
-	return defFormatter{s, &si}
-}
-
-type defFormatter struct {
-	def  *graph.Def
-	data *DefData
-}
-
-func (f defFormatter) Language() string { return "CSS" }
-
-func (f defFormatter) DefKeyword() string { return f.data.Keyword }
-
-func (f defFormatter) Kind() string { return f.data.Kind }
-
-func (f defFormatter) NameAndTypeSeparator() string { return f.data.Separator }
-
-func (f defFormatter) Type(qual graph.Qualification) string { return f.data.Type }
-
-func (f defFormatter) Name(qual graph.Qualification) string { return f.def.Name }

--- a/graph.go
+++ b/graph.go
@@ -90,7 +90,7 @@ func Graph(units unit.SourceUnits) (*graph.Output, error) {
 type selector string
 
 // selectors represents a group of selectors used to keep track uniqueness.
-type selectors map[selector]selector
+type selectors map[selector]bool
 
 // addSelector & selectorExists represents functions that perform actions on `selectors` type.
 type addSelector func(s selector)
@@ -142,7 +142,7 @@ func doGraph(u *unit.SourceUnit) (*graph.Output, error) {
 		return false
 	}
 	addSel = func(s selector) {
-		sels[s] = s
+		sels[s] = true
 	}
 
 	// Iterate over u.Files, for each file the process performed can be described as follow:

--- a/graph.go
+++ b/graph.go
@@ -308,7 +308,12 @@ func findOffsets(fileText string, line, column int, token string) (start, end in
 	return -1, -1 // not found.
 }
 
+var vendorPrefixRegExp = regexp.MustCompile("^-webkit-|^-moz-|^-ms-|^-o-")
+
 // mdnDefPath returns the mozilla developer network CSS reference URL for the given css property.
 func mdnDefPath(cssProperty string) string {
+	if strings.HasPrefix(cssProperty, "-webkit-") || strings.HasPrefix(cssProperty, "-moz-") || strings.HasPrefix(cssProperty, "-ms-") || strings.HasPrefix(cssProperty, "-o-") {
+		return mdnCSSReferenceURL + vendorPrefixRegExp.ReplaceAllString(cssProperty, "")
+	}
 	return mdnCSSReferenceURL + cssProperty
 }

--- a/graph.go
+++ b/graph.go
@@ -159,7 +159,8 @@ func doGraph(u *unit.SourceUnit) (*graph.Output, error) {
 		if isCSSFile(f) {
 			stylesheet, err := cssParser.Parse(data)
 			if err != nil {
-				return nil, err
+				log.Printf("failed to parse a source unit file: %s", err)
+				continue
 			}
 			for _, r := range stylesheet.Rules {
 				defs, err := getCSSDefs(u, data, f, r, selExists, addSel)

--- a/graph.go
+++ b/graph.go
@@ -185,6 +185,8 @@ func getCSSDefs(u *unit.SourceUnit, data string, filePath string, r *css.Rule, s
 	defs := []*graph.Def{}
 	for _, s := range r.Selectors {
 		defStart, defEnd := findOffsets(data, s.Line, s.Column, s.Value)
+
+		// TODO (chris): remove this when frontend is improved to handle this case.
 		if defStart == 0 { // UI line highlighting doesn't work for graph.Def.DefStart = 0, remove this after fix the UI or other workaround.
 			defStart = 1
 		}

--- a/graph.go
+++ b/graph.go
@@ -210,7 +210,7 @@ func getCSSDefs(u *unit.SourceUnit, data string, filePath string, r *css.Rule, s
 		}
 		defs = append(defs, &graph.Def{
 			DefKey: graph.DefKey{
-				UnitType: "Dir",
+				UnitType: "basic-css",
 				Unit:     u.Name,
 				Path:     selStr,
 			},
@@ -277,7 +277,7 @@ L:
 					l := len([]byte(val))
 					end = uint32(start + uint32(l))
 					refs = append(refs, &graph.Ref{
-						DefUnitType: "Dir",
+						DefUnitType: "basic-css",
 						DefUnit:     u.Name,
 						DefPath:     prefix + val,
 						Unit:        u.Name,

--- a/graph.go
+++ b/graph.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/net/html"
+	"github.com/chris-ramon/net/html"
 
 	cssParser "github.com/chris-ramon/douceur/parser"
 	"sourcegraph.com/sourcegraph/srclib/graph"
@@ -152,10 +152,8 @@ func Graph(units unit.SourceUnits) (*graph.Output, error) {
 							DefPath:     prefix + attr.Val,
 							Unit:        u.Name,
 							File:        filepath.ToSlash(currentFile),
-							// TODO(chris): Add the following start/end offset's.
-							// `golang.org/x/net/html` does not expose line/column or offsets for the given token.
-							//Start:       uint32(z.Data.Start),
-							//End:         uint32(z.Data.End),
+							Start:       uint32(attr.ValStart),
+							End:         uint32(attr.ValEnd),
 						})
 					}
 				}

--- a/scan.go
+++ b/scan.go
@@ -57,6 +57,7 @@ func (c *ScanCmd) Execute(args []string) error {
 	u := unit.SourceUnit{
 		Name: filepath.Base(CWD),
 		Type: "Dir",
+		Dir:  ".",
 	}
 	units := []*unit.SourceUnit{&u}
 
@@ -69,7 +70,7 @@ func (c *ScanCmd) Execute(args []string) error {
 		if f.IsDir() {
 			return nil
 		}
-		if isCSSFile(path) {
+		if isCSSFile(path) || isHTMLFile(path) {
 			rp, err := filepath.Rel(CWD, path)
 			if err != nil {
 				return err
@@ -93,4 +94,8 @@ func (c *ScanCmd) Execute(args []string) error {
 
 func isCSSFile(filename string) bool {
 	return filepath.Ext(filename) == ".css" && !strings.HasSuffix(filename, ".min.css")
+}
+
+func isHTMLFile(filename string) bool {
+	return filepath.Ext(filename) == ".html" && !strings.HasSuffix(filename, ".min.html")
 }

--- a/scan.go
+++ b/scan.go
@@ -56,7 +56,7 @@ func (c *ScanCmd) Execute(args []string) error {
 	// ScanCmd writes to Stdout only a single unit which represents all CSS files found on CWD.
 	u := unit.SourceUnit{
 		Name: filepath.Base(CWD),
-		Type: "Dir",
+		Type: "basic-css",
 		Dir:  ".",
 	}
 	units := []*unit.SourceUnit{&u}

--- a/scan.go
+++ b/scan.go
@@ -97,5 +97,12 @@ func isCSSFile(filename string) bool {
 }
 
 func isHTMLFile(filename string) bool {
-	return filepath.Ext(filename) == ".html" && !strings.HasSuffix(filename, ".min.html")
+	f := strings.ToLower(filename)
+	if filepath.Ext(f) == ".htm" && !strings.HasSuffix(f, ".min.htm") {
+		return true
+	}
+	if filepath.Ext(f) == ".html" && !strings.HasSuffix(f, ".min.html") {
+		return true
+	}
+	return false
 }

--- a/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/Dir.graph.json
+++ b/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/Dir.graph.json
@@ -1,0 +1,528 @@
+{
+  "Defs": [
+    {
+      "UnitType": "Dir",
+      "Unit": "css-sample-0",
+      "Path": "#container",
+      "Name": "#container",
+      "File": "main.css",
+      "DefStart": 89,
+      "DefEnd": 99
+    },
+    {
+      "UnitType": "Dir",
+      "Unit": "css-sample-0",
+      "Path": ".active:focus",
+      "Name": ".active:focus",
+      "File": "main.css",
+      "DefStart": 773,
+      "DefEnd": 790
+    },
+    {
+      "UnitType": "Dir",
+      "Unit": "css-sample-0",
+      "Path": ".alert-info",
+      "Name": ".alert-info",
+      "File": "main.css",
+      "DefStart": 1,
+      "DefEnd": 11
+    },
+    {
+      "UnitType": "Dir",
+      "Unit": "css-sample-0",
+      "Path": ".btn",
+      "Name": ".btn",
+      "File": "main.css",
+      "DefStart": 269,
+      "DefEnd": 273
+    },
+    {
+      "UnitType": "Dir",
+      "Unit": "css-sample-0",
+      "Path": ".btn-default",
+      "Name": ".btn-default",
+      "File": "main.css",
+      "DefStart": 967,
+      "DefEnd": 979
+    },
+    {
+      "UnitType": "Dir",
+      "Unit": "css-sample-0",
+      "Path": ".btn-sm",
+      "Name": ".btn-sm",
+      "File": "main.css",
+      "DefStart": 1048,
+      "DefEnd": 1055
+    },
+    {
+      "UnitType": "Dir",
+      "Unit": "css-sample-0",
+      "Path": ".btn:active:focus",
+      "Name": ".btn:active:focus",
+      "File": "main.css",
+      "DefStart": 770,
+      "DefEnd": 787
+    },
+    {
+      "UnitType": "Dir",
+      "Unit": "css-sample-0",
+      "Path": ".btn:focus",
+      "Name": ".btn:focus",
+      "File": "main.css",
+      "DefStart": 769,
+      "DefEnd": 779
+    },
+    {
+      "UnitType": "Dir",
+      "Unit": "css-sample-0",
+      "Path": ".container-inner",
+      "Name": ".container-inner",
+      "File": "main.css",
+      "DefStart": 172,
+      "DefEnd": 201
+    },
+    {
+      "UnitType": "Dir",
+      "Unit": "css-sample-0",
+      "Path": ".focus",
+      "Name": ".focus",
+      "File": "main.css",
+      "DefStart": 774,
+      "DefEnd": 784
+    },
+    {
+      "UnitType": "Dir",
+      "Unit": "css-sample-0",
+      "Path": ".paragraph",
+      "Name": ".paragraph",
+      "File": "main.css",
+      "DefStart": 230,
+      "DefEnd": 241
+    }
+  ],
+  "Refs": [
+    {
+      "DefUnitType": "Dir",
+      "DefUnit": "css-sample-0",
+      "DefPath": "#container",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 174,
+      "End": 183
+    },
+    {
+      "DefUnitType": "Dir",
+      "DefUnit": "css-sample-0",
+      "DefPath": ".alert-info",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 271,
+      "End": 281
+    },
+    {
+      "DefUnitType": "Dir",
+      "DefUnit": "css-sample-0",
+      "DefPath": ".alert-info",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 378,
+      "End": 388
+    },
+    {
+      "DefUnitType": "Dir",
+      "DefUnit": "css-sample-0",
+      "DefPath": ".btn-default",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 426,
+      "End": 437
+    },
+    {
+      "DefUnitType": "Dir",
+      "DefUnit": "css-sample-0",
+      "DefPath": ".btn-default",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 518,
+      "End": 529
+    },
+    {
+      "DefUnitType": "Dir",
+      "DefUnit": "css-sample-0",
+      "DefPath": ".btn-sm",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 530,
+      "End": 536
+    },
+    {
+      "DefUnitType": "Dir",
+      "DefUnit": "css-sample-0",
+      "DefPath": ".btn",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 422,
+      "End": 425
+    },
+    {
+      "DefUnitType": "Dir",
+      "DefUnit": "css-sample-0",
+      "DefPath": ".btn",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 514,
+      "End": 517
+    },
+    {
+      "DefUnitType": "Dir",
+      "DefUnit": "css-sample-0",
+      "DefPath": ".container-inner",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 210,
+      "End": 225
+    },
+    {
+      "DefUnitType": "Dir",
+      "DefUnit": "css-sample-0",
+      "DefPath": ".paragraph",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 325,
+      "End": 334
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-user-select",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 603,
+      "End": 619
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-touch-action",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 484,
+      "End": 500
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-user-select",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 633,
+      "End": 648
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-user-select",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 571,
+      "End": 590
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 34,
+      "End": 50
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 999,
+      "End": 1015
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-image",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 687,
+      "End": 703
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 1025,
+      "End": 1037
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 63,
+      "End": 75
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 1142,
+      "End": 1155
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 746,
+      "End": 759
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 713,
+      "End": 719
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 16,
+      "End": 21
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 984,
+      "End": 989
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/cursor",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 552,
+      "End": 558
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/display",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 278,
+      "End": 285
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/font-size",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 1103,
+      "End": 1112
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/font-size",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 344,
+      "End": 353
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 363,
+      "End": 374
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/line-height",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 1122,
+      "End": 1133
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/line-height",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 386,
+      "End": 397
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 324,
+      "End": 337
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-right",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 149,
+      "End": 161
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/outline-offset",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 942,
+      "End": 956
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/outline",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 872,
+      "End": 879
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/outline",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 896,
+      "End": 903
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding-left",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 127,
+      "End": 139
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding-left",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 246,
+      "End": 258
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding-right",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 104,
+      "End": 117
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding-right",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 206,
+      "End": 219
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 1082,
+      "End": 1089
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 303,
+      "End": 310
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/text-align",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 413,
+      "End": 423
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 522,
+      "End": 534
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/user-select",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 666,
+      "End": 677
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 458,
+      "End": 472
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/white-space",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 435,
+      "End": 446
+    }
+  ]
+}

--- a/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/Dir.unit.json
+++ b/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/Dir.unit.json
@@ -1,1 +1,0 @@
-{"Name":"css-sample-0","Type":"Dir","Files":["main.css","main.html"],"Dir":"."}

--- a/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/Dir.unit.json
+++ b/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/Dir.unit.json
@@ -1,0 +1,1 @@
+{"Name":"css-sample-0","Type":"Dir","Files":["main.css","main.html"],"Dir":"."}

--- a/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/basic-css.graph.json
+++ b/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/basic-css.graph.json
@@ -3,7 +3,7 @@
     {
       "UnitType": "basic-css",
       "Unit": "css-sample-0",
-      "Path": "#container",
+      "Path": "main.css#container",
       "Name": "#container",
       "File": "main.css",
       "DefStart": 89,
@@ -19,7 +19,7 @@
     {
       "UnitType": "basic-css",
       "Unit": "css-sample-0",
-      "Path": ".active:focus",
+      "Path": "main.css.active:focus",
       "Name": ".active:focus",
       "File": "main.css",
       "DefStart": 773,
@@ -35,7 +35,7 @@
     {
       "UnitType": "basic-css",
       "Unit": "css-sample-0",
-      "Path": ".alert-info",
+      "Path": "main.css.alert-info",
       "Name": ".alert-info",
       "File": "main.css",
       "DefStart": 1,
@@ -51,7 +51,7 @@
     {
       "UnitType": "basic-css",
       "Unit": "css-sample-0",
-      "Path": ".btn",
+      "Path": "main.css.btn",
       "Name": ".btn",
       "File": "main.css",
       "DefStart": 269,
@@ -67,7 +67,7 @@
     {
       "UnitType": "basic-css",
       "Unit": "css-sample-0",
-      "Path": ".btn-default",
+      "Path": "main.css.btn-default",
       "Name": ".btn-default",
       "File": "main.css",
       "DefStart": 967,
@@ -83,7 +83,7 @@
     {
       "UnitType": "basic-css",
       "Unit": "css-sample-0",
-      "Path": ".btn-sm",
+      "Path": "main.css.btn-sm",
       "Name": ".btn-sm",
       "File": "main.css",
       "DefStart": 1048,
@@ -99,7 +99,7 @@
     {
       "UnitType": "basic-css",
       "Unit": "css-sample-0",
-      "Path": ".btn:active:focus",
+      "Path": "main.css.btn:active:focus",
       "Name": ".btn:active:focus",
       "File": "main.css",
       "DefStart": 770,
@@ -115,7 +115,7 @@
     {
       "UnitType": "basic-css",
       "Unit": "css-sample-0",
-      "Path": ".btn:focus",
+      "Path": "main.css.btn:focus",
       "Name": ".btn:focus",
       "File": "main.css",
       "DefStart": 769,
@@ -131,7 +131,7 @@
     {
       "UnitType": "basic-css",
       "Unit": "css-sample-0",
-      "Path": ".container-inner",
+      "Path": "main.css.container-inner",
       "Name": ".container-inner",
       "File": "main.css",
       "DefStart": 172,
@@ -147,7 +147,7 @@
     {
       "UnitType": "basic-css",
       "Unit": "css-sample-0",
-      "Path": ".focus",
+      "Path": "main.css.focus",
       "Name": ".focus",
       "File": "main.css",
       "DefStart": 774,
@@ -163,7 +163,7 @@
     {
       "UnitType": "basic-css",
       "Unit": "css-sample-0",
-      "Path": ".paragraph",
+      "Path": "main.css.paragraph",
       "Name": ".paragraph",
       "File": "main.css",
       "DefStart": 230,

--- a/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/basic-css.graph.json
+++ b/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/basic-css.graph.json
@@ -1,108 +1,185 @@
 {
   "Defs": [
     {
-      "UnitType": "Dir",
+      "UnitType": "basic-css",
       "Unit": "css-sample-0",
       "Path": "#container",
       "Name": "#container",
       "File": "main.css",
       "DefStart": 89,
-      "DefEnd": 99
+      "DefEnd": 99,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "id",
+        "Separator": ""
+      }
     },
     {
-      "UnitType": "Dir",
+      "UnitType": "basic-css",
       "Unit": "css-sample-0",
       "Path": ".active:focus",
       "Name": ".active:focus",
       "File": "main.css",
       "DefStart": 773,
-      "DefEnd": 790
+      "DefEnd": 790,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
     },
     {
-      "UnitType": "Dir",
+      "UnitType": "basic-css",
       "Unit": "css-sample-0",
       "Path": ".alert-info",
       "Name": ".alert-info",
       "File": "main.css",
       "DefStart": 1,
-      "DefEnd": 11
+      "DefEnd": 11,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
     },
     {
-      "UnitType": "Dir",
+      "UnitType": "basic-css",
       "Unit": "css-sample-0",
       "Path": ".btn",
       "Name": ".btn",
       "File": "main.css",
       "DefStart": 269,
-      "DefEnd": 273
+      "DefEnd": 273,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
     },
     {
-      "UnitType": "Dir",
+      "UnitType": "basic-css",
       "Unit": "css-sample-0",
       "Path": ".btn-default",
       "Name": ".btn-default",
       "File": "main.css",
       "DefStart": 967,
-      "DefEnd": 979
+      "DefEnd": 979,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
     },
     {
-      "UnitType": "Dir",
+      "UnitType": "basic-css",
       "Unit": "css-sample-0",
       "Path": ".btn-sm",
       "Name": ".btn-sm",
       "File": "main.css",
       "DefStart": 1048,
-      "DefEnd": 1055
+      "DefEnd": 1055,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
     },
     {
-      "UnitType": "Dir",
+      "UnitType": "basic-css",
       "Unit": "css-sample-0",
       "Path": ".btn:active:focus",
       "Name": ".btn:active:focus",
       "File": "main.css",
       "DefStart": 770,
-      "DefEnd": 787
+      "DefEnd": 787,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
     },
     {
-      "UnitType": "Dir",
+      "UnitType": "basic-css",
       "Unit": "css-sample-0",
       "Path": ".btn:focus",
       "Name": ".btn:focus",
       "File": "main.css",
       "DefStart": 769,
-      "DefEnd": 779
+      "DefEnd": 779,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
     },
     {
-      "UnitType": "Dir",
+      "UnitType": "basic-css",
       "Unit": "css-sample-0",
       "Path": ".container-inner",
       "Name": ".container-inner",
       "File": "main.css",
       "DefStart": 172,
-      "DefEnd": 201
+      "DefEnd": 201,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
     },
     {
-      "UnitType": "Dir",
+      "UnitType": "basic-css",
       "Unit": "css-sample-0",
       "Path": ".focus",
       "Name": ".focus",
       "File": "main.css",
       "DefStart": 774,
-      "DefEnd": 784
+      "DefEnd": 784,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
     },
     {
-      "UnitType": "Dir",
+      "UnitType": "basic-css",
       "Unit": "css-sample-0",
       "Path": ".paragraph",
       "Name": ".paragraph",
       "File": "main.css",
       "DefStart": 230,
-      "DefEnd": 241
+      "DefEnd": 241,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
     }
   ],
   "Refs": [
     {
-      "DefUnitType": "Dir",
+      "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
       "DefPath": "#container",
       "Unit": "css-sample-0",
@@ -111,7 +188,7 @@
       "End": 183
     },
     {
-      "DefUnitType": "Dir",
+      "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
       "DefPath": ".alert-info",
       "Unit": "css-sample-0",
@@ -120,7 +197,7 @@
       "End": 281
     },
     {
-      "DefUnitType": "Dir",
+      "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
       "DefPath": ".alert-info",
       "Unit": "css-sample-0",
@@ -129,7 +206,7 @@
       "End": 388
     },
     {
-      "DefUnitType": "Dir",
+      "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
       "DefPath": ".btn-default",
       "Unit": "css-sample-0",
@@ -138,7 +215,7 @@
       "End": 437
     },
     {
-      "DefUnitType": "Dir",
+      "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
       "DefPath": ".btn-default",
       "Unit": "css-sample-0",
@@ -147,7 +224,7 @@
       "End": 529
     },
     {
-      "DefUnitType": "Dir",
+      "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
       "DefPath": ".btn-sm",
       "Unit": "css-sample-0",
@@ -156,7 +233,7 @@
       "End": 536
     },
     {
-      "DefUnitType": "Dir",
+      "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
       "DefPath": ".btn",
       "Unit": "css-sample-0",
@@ -165,7 +242,7 @@
       "End": 425
     },
     {
-      "DefUnitType": "Dir",
+      "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
       "DefPath": ".btn",
       "Unit": "css-sample-0",
@@ -174,7 +251,7 @@
       "End": 517
     },
     {
-      "DefUnitType": "Dir",
+      "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
       "DefPath": ".container-inner",
       "Unit": "css-sample-0",
@@ -183,49 +260,13 @@
       "End": 225
     },
     {
-      "DefUnitType": "Dir",
+      "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
       "DefPath": ".paragraph",
       "Unit": "css-sample-0",
       "File": "main.html",
       "Start": 325,
       "End": 334
-    },
-    {
-      "DefUnitType": "URL",
-      "DefUnit": "MDN",
-      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-user-select",
-      "Unit": "css-sample-0",
-      "File": "main.css",
-      "Start": 603,
-      "End": 619
-    },
-    {
-      "DefUnitType": "URL",
-      "DefUnit": "MDN",
-      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-touch-action",
-      "Unit": "css-sample-0",
-      "File": "main.css",
-      "Start": 484,
-      "End": 500
-    },
-    {
-      "DefUnitType": "URL",
-      "DefUnit": "MDN",
-      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-user-select",
-      "Unit": "css-sample-0",
-      "File": "main.css",
-      "Start": 633,
-      "End": 648
-    },
-    {
-      "DefUnitType": "URL",
-      "DefUnit": "MDN",
-      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-user-select",
-      "Unit": "css-sample-0",
-      "File": "main.css",
-      "Start": 571,
-      "End": 590
     },
     {
       "DefUnitType": "URL",
@@ -494,8 +535,44 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action",
       "Unit": "css-sample-0",
       "File": "main.css",
+      "Start": 484,
+      "End": 500
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action",
+      "Unit": "css-sample-0",
+      "File": "main.css",
       "Start": 522,
       "End": 534
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/user-select",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 571,
+      "End": 590
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/user-select",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 603,
+      "End": 619
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/user-select",
+      "Unit": "css-sample-0",
+      "File": "main.css",
+      "Start": 633,
+      "End": 648
     },
     {
       "DefUnitType": "URL",

--- a/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/basic-css.unit.json
+++ b/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/basic-css.unit.json
@@ -1,0 +1,1 @@
+{"Name":"css-sample-0","Type":"basic-css","Files":["main.css","main.html"],"Dir":"."}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,16 +3,16 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "9AX1Qo5TlMveGCqhyBTla7zN5z0=",
+			"checksumSHA1": "8axvkTWWvYRZK2fy0L5R/vBgJwU=",
 			"path": "github.com/chris-ramon/douceur/css",
-			"revision": "c0a5b8aea4ffb106eb8992cbab4d4bb1bad3467c",
-			"revisionTime": "2016-05-11T08:54:35Z"
+			"revision": "798661fabbb17c911d012532892d228b3564a69d",
+			"revisionTime": "2016-05-26T05:27:50Z"
 		},
 		{
 			"checksumSHA1": "aSaQE7tdF2u4gYwuDY1XHMSDTQc=",
 			"path": "github.com/chris-ramon/douceur/parser",
-			"revision": "c0a5b8aea4ffb106eb8992cbab4d4bb1bad3467c",
-			"revisionTime": "2016-05-11T08:54:35Z"
+			"revision": "798661fabbb17c911d012532892d228b3564a69d",
+			"revisionTime": "2016-05-26T05:27:50Z"
 		},
 		{
 			"checksumSHA1": "2XlHDO4qUqbFiztJ0SfDdrUThTQ=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,16 +3,16 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "UpgvFTq5cLoEhiE8ifLcgSHnX4k=",
+			"checksumSHA1": "9AX1Qo5TlMveGCqhyBTla7zN5z0=",
 			"path": "github.com/chris-ramon/douceur/css",
-			"revision": "9598891decbee665d727cefc8542f64367e49b8e",
-			"revisionTime": "2016-04-29T12:44:48-05:00"
+			"revision": "c0a5b8aea4ffb106eb8992cbab4d4bb1bad3467c",
+			"revisionTime": "2016-05-11T08:54:35Z"
 		},
 		{
-			"checksumSHA1": "4UVPezmltWDD2LZWDFEibGpCJws=",
+			"checksumSHA1": "aSaQE7tdF2u4gYwuDY1XHMSDTQc=",
 			"path": "github.com/chris-ramon/douceur/parser",
-			"revision": "9598891decbee665d727cefc8542f64367e49b8e",
-			"revisionTime": "2016-04-29T12:44:48-05:00"
+			"revision": "c0a5b8aea4ffb106eb8992cbab4d4bb1bad3467c",
+			"revisionTime": "2016-05-11T08:54:35Z"
 		},
 		{
 			"checksumSHA1": "N3LXf9Vm2RM0AE3DjhCmpiyK4Bc=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,10 +15,22 @@
 			"revisionTime": "2016-05-11T08:54:35Z"
 		},
 		{
-			"checksumSHA1": "N3LXf9Vm2RM0AE3DjhCmpiyK4Bc=",
+			"checksumSHA1": "2XlHDO4qUqbFiztJ0SfDdrUThTQ=",
+			"path": "github.com/chris-ramon/net/html",
+			"revision": "039f40b58670d886ddc81ee909d04cf755831e95",
+			"revisionTime": "2016-05-14T20:56:01Z"
+		},
+		{
+			"checksumSHA1": "sXkXtKcAWhM7jcbQSW9PcxH0hDg=",
+			"path": "github.com/chris-ramon/net/html/atom",
+			"revision": "039f40b58670d886ddc81ee909d04cf755831e95",
+			"revisionTime": "2016-05-14T20:56:01Z"
+		},
+		{
+			"checksumSHA1": "iZVulPMFFGC70xeLZJafiKzTn18=",
 			"path": "github.com/gogo/protobuf/proto",
-			"revision": "4f262e4b0f3a6cea646e15798109335551e21756",
-			"revisionTime": "2016-04-13T13:07:56Z"
+			"revision": "c18eea6ad611eecf94a9ba38471f59706199409e",
+			"revisionTime": "2016-05-11T09:34:45Z"
 		},
 		{
 			"checksumSHA1": "UNlILKZlAiLwYYwj70y+Q8n13D0=",
@@ -45,28 +57,16 @@
 			"revisionTime": "2015-01-10T16:24:53Z"
 		},
 		{
-			"checksumSHA1": "vqc3a+oTUGX8PmD0TS+qQ7gmN8I=",
-			"path": "golang.org/x/net/html",
-			"revision": "96dbb961a39ddccf16860cdd355bfa639c497f23",
-			"revisionTime": "2016-05-10T16:41:55Z"
-		},
-		{
-			"checksumSHA1": "00eQaGynDYrv3tL+C7l9xH0IDZg=",
-			"path": "golang.org/x/net/html/atom",
-			"revision": "96dbb961a39ddccf16860cdd355bfa639c497f23",
-			"revisionTime": "2016-05-10T16:41:55Z"
-		},
-		{
 			"checksumSHA1": "2bj5Jq3+RmE2blLnFUfkASYGTlg=",
 			"path": "golang.org/x/tools/godoc/vfs",
-			"revision": "5e468032ea9e193c60de97cfcd040ffa7a9b774e",
-			"revisionTime": "2016-04-17T16:37:22Z"
+			"revision": "c86fe5956d4575f29850535871a97abbd403a145",
+			"revisionTime": "2016-04-13T21:57:13Z"
 		},
 		{
 			"checksumSHA1": "Qwc7VecyIh84Ol8n9J9DUwZQtII=",
 			"path": "golang.org/x/tools/godoc/vfs/mapfs",
-			"revision": "5e468032ea9e193c60de97cfcd040ffa7a9b774e",
-			"revisionTime": "2016-04-17T16:37:22Z"
+			"revision": "c86fe5956d4575f29850535871a97abbd403a145",
+			"revisionTime": "2016-04-13T21:57:13Z"
 		},
 		{
 			"checksumSHA1": "thalOxMGUln4he8/AKgUOVgEgmg=",
@@ -75,40 +75,40 @@
 			"revisionTime": "2016-03-24T14:23:09Z"
 		},
 		{
-			"checksumSHA1": "seWWPqWX4VyY7hsix0woW6OYLAY=",
+			"checksumSHA1": "wMibXd2FzCwmV4WMCwh0D7bzxjE=",
 			"path": "sourcegraph.com/sourcegraph/srclib",
-			"revision": "23661cf6d279b9e47357744249e5a5cee04326d6",
-			"revisionTime": "2016-04-15T21:44:09Z"
+			"revision": "3d98aa2c585ca3a13dd4ce2fb825711e00afbfdd",
+			"revisionTime": "2016-05-12T20:13:36Z"
 		},
 		{
 			"checksumSHA1": "50qafmhTyHoz2X+UbQeqJKcELjw=",
 			"path": "sourcegraph.com/sourcegraph/srclib/ann",
-			"revision": "23661cf6d279b9e47357744249e5a5cee04326d6",
-			"revisionTime": "2016-04-15T21:44:09Z"
+			"revision": "3d98aa2c585ca3a13dd4ce2fb825711e00afbfdd",
+			"revisionTime": "2016-05-12T20:13:36Z"
 		},
 		{
 			"checksumSHA1": "6Gr29dGzABWc6eUncFUs7LMVDVY=",
 			"path": "sourcegraph.com/sourcegraph/srclib/buildstore",
-			"revision": "23661cf6d279b9e47357744249e5a5cee04326d6",
-			"revisionTime": "2016-04-15T21:44:09Z"
+			"revision": "3d98aa2c585ca3a13dd4ce2fb825711e00afbfdd",
+			"revisionTime": "2016-05-12T20:13:36Z"
 		},
 		{
-			"checksumSHA1": "hYUGZVDD9sRAxEGqEvfeQUpzK6o=",
+			"checksumSHA1": "IlhJpzgSvjk9dQXGcZARbjn3D/I=",
 			"path": "sourcegraph.com/sourcegraph/srclib/graph",
-			"revision": "23661cf6d279b9e47357744249e5a5cee04326d6",
-			"revisionTime": "2016-04-15T21:44:09Z"
+			"revision": "3d98aa2c585ca3a13dd4ce2fb825711e00afbfdd",
+			"revisionTime": "2016-05-12T20:13:36Z"
 		},
 		{
 			"checksumSHA1": "DO2ClRpKhE9dkk3dJ2L0tdkDnRc=",
 			"path": "sourcegraph.com/sourcegraph/srclib/unit",
-			"revision": "23661cf6d279b9e47357744249e5a5cee04326d6",
-			"revisionTime": "2016-04-15T21:44:09Z"
+			"revision": "3d98aa2c585ca3a13dd4ce2fb825711e00afbfdd",
+			"revisionTime": "2016-05-12T20:13:36Z"
 		},
 		{
-			"checksumSHA1": "GZZtDCxhiXpKrgrO7nif2eStNIQ=",
+			"checksumSHA1": "sX55Z0+7/lbGcM2XgxpFylHQCIc=",
 			"path": "sourcegraph.com/sourcegraph/srclib/util",
-			"revision": "23661cf6d279b9e47357744249e5a5cee04326d6",
-			"revisionTime": "2016-04-15T21:44:09Z"
+			"revision": "3d98aa2c585ca3a13dd4ce2fb825711e00afbfdd",
+			"revisionTime": "2016-05-12T20:13:36Z"
 		},
 		{
 			"checksumSHA1": "GRBoSaxkWfXT9BIP2M87IePcEn8=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -57,12 +57,6 @@
 			"revisionTime": "2015-01-10T16:24:53Z"
 		},
 		{
-			"checksumSHA1": "00eQaGynDYrv3tL+C7l9xH0IDZg=",
-			"path": "golang.org/x/net/html/atom",
-			"revision": "96dbb961a39ddccf16860cdd355bfa639c497f23",
-			"revisionTime": "2016-05-10T16:41:55Z"
-		},
-		{
 			"checksumSHA1": "2bj5Jq3+RmE2blLnFUfkASYGTlg=",
 			"path": "golang.org/x/tools/godoc/vfs",
 			"revision": "c86fe5956d4575f29850535871a97abbd403a145",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -51,6 +51,12 @@
 			"revisionTime": "2016-05-10T16:41:55Z"
 		},
 		{
+			"checksumSHA1": "00eQaGynDYrv3tL+C7l9xH0IDZg=",
+			"path": "golang.org/x/net/html/atom",
+			"revision": "96dbb961a39ddccf16860cdd355bfa639c497f23",
+			"revisionTime": "2016-05-10T16:41:55Z"
+		},
+		{
 			"checksumSHA1": "2bj5Jq3+RmE2blLnFUfkASYGTlg=",
 			"path": "golang.org/x/tools/godoc/vfs",
 			"revision": "5e468032ea9e193c60de97cfcd040ffa7a9b774e",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,8 +45,8 @@
 			"revisionTime": "2015-01-10T16:24:53Z"
 		},
 		{
-			"checksumSHA1": "00eQaGynDYrv3tL+C7l9xH0IDZg=",
-			"path": "golang.org/x/net/html/atom",
+			"checksumSHA1": "vqc3a+oTUGX8PmD0TS+qQ7gmN8I=",
+			"path": "golang.org/x/net/html",
 			"revision": "96dbb961a39ddccf16860cdd355bfa639c497f23",
 			"revisionTime": "2016-05-10T16:41:55Z"
 		},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -57,6 +57,12 @@
 			"revisionTime": "2015-01-10T16:24:53Z"
 		},
 		{
+			"checksumSHA1": "00eQaGynDYrv3tL+C7l9xH0IDZg=",
+			"path": "golang.org/x/net/html/atom",
+			"revision": "96dbb961a39ddccf16860cdd355bfa639c497f23",
+			"revisionTime": "2016-05-10T16:41:55Z"
+		},
+		{
 			"checksumSHA1": "2bj5Jq3+RmE2blLnFUfkASYGTlg=",
 			"path": "golang.org/x/tools/godoc/vfs",
 			"revision": "c86fe5956d4575f29850535871a97abbd403a145",


### PR DESCRIPTION
#### Details

- [x] Scanner: Update scanner to include HTML files to the repo source unit.
- [x] Grapher: Create definitions for each CSS selector.
- [x] Grapher: Create reference for each CSS selector found on repo's HTML files.
- [x] CSS parser changes (https://github.com/chris-ramon/douceur/commit/c0a5b8aea4ffb106eb8992cbab4d4bb1bad3467c & https://github.com/chris-ramon/douceur/pull/1):
  - Improve `parser` to include selector's additional info such as: Token's line & column.
  - Add missing vendor prefixed at-rules.
- [x] Grapher: Initial support for analyzing HTML&CSS files from sub-directories.
- [x] Tests: Adds tests, testeable via `srclib test`:

  ```
  (srclib-css)-> srclib test
  css-sample-0 PASS
  ```