### PR TITLE
refs for CSS selectors.

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -87,78 +87,60 @@ func Graph(units unit.SourceUnits) (*graph.Output, error) {
 	return o, nil
 }
 
-// selector represents either a single selector or a chain of selectors.
+// selector represents a CSS selector, which might be:
+// - Comma separated selectors chain, Eg. ".panel, .panel-body, .panel-info".
+// - Descendant selector, Eg. "h1.title".
+// - Single selector, Eg. "#container".
 type selector string
 
-// selectors represents a group of selectors used to keep track uniqueness.
-type selectors map[string]bool
-
-// addSelector & selectorExists represents functions that perform actions on `selectors` type.
-type addSelector func(s selector, filePath string)
-type selectorExists func(s selector, filePath string) bool
-
-var lastSelectorRegexp = regexp.MustCompile(".*([\\.\\#].+)")
-
-func selSplitFn(r rune) bool {
-	return r == '>' || r == '+' || r == '~'
+func (s *selector) String() string {
+	return string(*s)
 }
 
-// lastSelector returns the last selector from given selector chain.
+func newSelector(sel string) *selector {
+	s := selector(sel)
+	return &s
+}
+
+// descSelectorRegexp is a regexp pattern that matches individual selectors from a descendant selector, Eg. "h1.title".
+var descSelectorRegexp = regexp.MustCompile(".*([\\.\\#].+)")
+
+// selSplitFn returns true if given CSS combinator is valid.
+func selSplitFn(combinator rune) bool {
+	return combinator == '>' || combinator == '+' || combinator == '~'
+}
+
+// lastSelector returns last selector from given selectors chain.
 func lastSelector(s string) *selector {
-	// Splits `s` into a slice of selectors. It might be a single selector or a chain of selectors(Eg. ".panel > .panel-body + .table").
 	selectors := strings.FieldsFunc(s, selSplitFn)
-
-	// there may be no selectors
-	if len(selectors) == 0 {
+	lastSel := strings.TrimSpace(selectors[len(selectors)-1])
+	matches := descSelectorRegexp.FindStringSubmatch(lastSel)
+	if len(matches) != 2 {
 		return nil
 	}
-
-	// sel is the single or last selector from selectors chain.
-	sel := strings.TrimSpace(selectors[len(selectors)-1])
-
-	// sel might still be a chain of selectors(Eg. "h1.title")
-	// `lastSelectorRegexp` is used to obtain the last selector which starts either with "." or "#".
-	m := lastSelectorRegexp.FindStringSubmatch(sel)
-	if len(m) != 2 {
-		return nil
-	}
-	var l selector
-	l = selector(m[1])
-	return &l
+	lastSelElement := matches[1]
+	return newSelector(lastSelElement)
 }
 
-func selectorKey(filePath string, s selector) string {
-	return fmt.Sprintf("%s:%s", filePath, string(s))
-}
+// selectorDefExist returns true if given `def` exists in a set of definitions.
+type selectorDefExist func(def *graph.Def) bool
 
 func doGraph(u *unit.SourceUnit) (*graph.Output, error) {
 	out := graph.Output{}
 
-	// At the moment we support a unique selector per `out`.
-	var (
-		// sels are used to keep track which selectors exists for `out`.
-		sels selectors = make(selectors, 0)
-
-		// selExists is used to check if a given selector exits in `sels`.
-		selExists selectorExists
-
-		// addSel is used to add a given selector to `sels`.
-		addSel addSelector
-	)
-	selExists = func(s selector, filePath string) bool {
-		if _, found := sels[selectorKey(filePath, s)]; found {
-			return true
+	var defExist selectorDefExist
+	defExist = func(def *graph.Def) bool {
+		for _, d := range out.Defs {
+			if d.Name == def.Name && d.DefKey.Path == def.DefKey.Path {
+				return true
+			}
 		}
 		return false
 	}
-	addSel = func(s selector, filePath string) {
-		sels[selectorKey(filePath, s)] = true
-	}
 
-	// Iterate over u.Files, for each file the process performed can be described as follow:
-	// 1. Read the file and parse its data.
-	// 2. For CSS files: for each selector found a graph.Def is created and for each property of that selector a graph.Ref is created.
-	// 3. For HTML files: for each tag attribute(id and class) a graph.Ref is created.
+	// For each CSS file on `u.Files`:
+	// - Create a `graph.Def` for each CSS selector.
+	// - Create a `graph.Ref` for each CSS selector property.
 	for _, f := range u.Files {
 		fileBytes, err := ioutil.ReadFile(f)
 		if err != nil {
@@ -173,71 +155,91 @@ func doGraph(u *unit.SourceUnit) (*graph.Output, error) {
 				continue
 			}
 			for _, r := range stylesheet.Rules {
-				defs, err := getCSSDefs(u, data, f, r, selExists, addSel)
-				if err != nil {
-					return nil, err
+				// `r.Selectors` is either a single selector or a selectors chain.
+				for _, s := range r.Selectors {
+					if s.Value == "" {
+						// If `s.Value` is an empty selector, might be due to malformed CSS syntax.
+						log.Printf("unexpected empty selector, rules: %+v", stylesheet.Rules)
+						continue
+					}
+					defs, err := cssDefs(*s, u, data, f, r, defExist)
+					if err != nil {
+						return nil, err
+					}
+					out.Defs = append(out.Defs, defs...)
 				}
-				out.Defs = append(out.Defs, defs...)
-				out.Refs = append(out.Refs, getCSSRefs(u, data, f, r)...)
+				out.Refs = append(out.Refs, cssRefs(u, data, f, r)...)
 			}
-		} else if isHTMLFile(f) {
-			refs, err := getHTMLRefs(u, data, f)
+		}
+	}
+
+	// For each HTML file on `u.Files`:
+	// - Create a `graph.Ref` for each element within each HTML tag id/class attribute, which points to an existing `graph.Def` previously created.
+	for _, f := range u.Files {
+		fileBytes, err := ioutil.ReadFile(f)
+		if err != nil {
+			log.Printf("failed to read a source unit file: %s", err)
+			continue
+		}
+		data := string(fileBytes)
+		if isHTMLFile(f) {
+			refs, err := htmlRefs(u, data, f, out.Defs)
 			if err != nil {
 				return nil, err
 			}
 			out.Refs = append(out.Refs, refs...)
 		}
 	}
+
 	return &out, nil
 }
 
-func getCSSDefs(u *unit.SourceUnit, data string, filePath string, r *css.Rule, selExists selectorExists, addSel addSelector) ([]*graph.Def, error) {
+func cssDefs(s css.Selector, u *unit.SourceUnit, data string, filePath string, r *css.Rule, defExist selectorDefExist) ([]*graph.Def, error) {
 	defs := []*graph.Def{}
-	for _, s := range r.Selectors {
-		defStart, defEnd := findOffsets(data, s.Line, s.Column, s.Value)
+	defStart, defEnd := findOffsets(data, s.Line, s.Column, s.Value)
 
-		// TODO (chris): remove this when frontend is improved to handle this case.
-		if defStart == 0 { // UI line highlighting doesn't work for graph.Def.DefStart = 0, remove this after fix the UI or other workaround.
-			defStart = 1
-		}
-
-		// Obtains last selector from the selectors chain `s.Value`.
-		sel := lastSelector(s.Value)
-		if sel == nil {
-			continue
-		}
-
-		// Current implementation supports a unique selector per CSS file and per graph.Output.
-		if selExists(*sel, filePath) {
-			continue
-		}
-		addSel(*sel, filePath)
-
-		selStr := string(*sel)
-		d, err := json.Marshal(css_def.DefData{
-			Keyword: "selector",
-			Kind:    selectorKind(selStr),
-		})
-		if err != nil {
-			return defs, err
-		}
-		defs = append(defs, &graph.Def{
-			DefKey: graph.DefKey{
-				UnitType: "basic-css",
-				Unit:     u.Name,
-				Path:     selectorDefPath(filePath, *sel),
-			},
-			Name:     selStr,
-			File:     filepath.ToSlash(filePath),
-			DefStart: uint32(defStart),
-			DefEnd:   uint32(defEnd),
-			Data:     d,
-		})
+	// TODO (chris): remove this when frontend is improved to handle this case.
+	if defStart == 0 { // UI line highlighting doesn't work for graph.Def.DefStart = 0, remove this after fix the UI or other workaround.
+		defStart = 1
 	}
+
+	// Obtain last selector from a selectors chain.
+	sel := lastSelector(s.Value)
+	if sel == nil {
+		return nil, nil
+	}
+
+	selStr := string(*sel)
+	d, err := json.Marshal(css_def.DefData{
+		Keyword: "selector",
+		Kind:    selectorKind(selStr),
+	})
+	if err != nil {
+		return nil, err
+	}
+	def := &graph.Def{
+		DefKey: graph.DefKey{
+			UnitType: "basic-css",
+			Unit:     u.Name,
+			Path:     selectorDefPath(filePath, *sel),
+		},
+		Name:     selStr,
+		File:     filepath.ToSlash(filePath),
+		DefStart: uint32(defStart),
+		DefEnd:   uint32(defEnd),
+		Data:     d,
+	}
+
+	// Checks if `def.Name`(CSS selector) already exists; if so, it should not be added, current implementation supports
+	// one `graph.Def` per one selector.
+	if defExist(def) {
+		return nil, nil
+	}
+	defs = append(defs, def)
 	return defs, nil
 }
 
-func getCSSRefs(u *unit.SourceUnit, data string, filePath string, r *css.Rule) []*graph.Ref {
+func cssRefs(u *unit.SourceUnit, data string, filePath string, r *css.Rule) []*graph.Ref {
 	refs := []*graph.Ref{}
 	for _, d := range r.Declarations {
 		s, e := findOffsets(data, d.Line, d.Column, d.Property)
@@ -254,21 +256,30 @@ func getCSSRefs(u *unit.SourceUnit, data string, filePath string, r *css.Rule) [
 	return refs
 }
 
-func getHTMLRefs(u *unit.SourceUnit, data string, filePath string) ([]*graph.Ref, error) {
+func htmlRefs(u *unit.SourceUnit, data string, filePath string, selectorDefs []*graph.Def) ([]*graph.Ref, error) {
 	refs := []*graph.Ref{}
-	cssFilePath := ""
-	z := html.NewTokenizer(strings.NewReader(data))
-L:
+
+	// linkTagsZ is a HTML tokenizer used to search for `<link rel="stylesheet" ...>` tags.
+	linkTagsZ := html.NewTokenizer(strings.NewReader(data))
+
+	// stylesheetHREFs is a slice which contains all the stylesheet HREFs found defined on HTML file `z`.
+	var stylesheetHREFs = []string{}
+
+	// Search for all the style tags defined on `data` to extract its HREFs to be later use, when resolving
+	// the definition path of CSS selector found on HTML tags id/class attributes.
+	// Not looking for style tags inside `LtagsZ`: To make sure all stylesheet HREFs are found first:
+	// `<link ...>` tags might be placed in different locations in the HTML document.
+LlinkTags:
 	for {
-		tt := z.Next()
+		tt := linkTagsZ.Next()
 		switch tt {
 		case html.ErrorToken:
-			if z.Err() != io.EOF {
-				return nil, z.Err()
+			if linkTagsZ.Err() != io.EOF {
+				return nil, linkTagsZ.Err()
 			}
-			break L
+			break LlinkTags
 		case html.StartTagToken, html.SelfClosingTagToken:
-			t := z.Token()
+			t := linkTagsZ.Token()
 			if t.Data == "link" {
 				isStylesheetLink := false
 				href := ""
@@ -281,9 +292,24 @@ L:
 					}
 				}
 				if isStylesheetLink {
-					cssFilePath = href
+					stylesheetHREFs = append(stylesheetHREFs, href)
 				}
 			}
+		}
+	}
+
+	tagsZ := html.NewTokenizer(strings.NewReader(data))
+LtagsZ:
+	for {
+		tt := tagsZ.Next()
+		switch tt {
+		case html.ErrorToken:
+			if tagsZ.Err() != io.EOF {
+				return nil, tagsZ.Err()
+			}
+			break LtagsZ
+		case html.StartTagToken, html.SelfClosingTagToken:
+			t := tagsZ.Token()
 			attrValSep := " "
 			for _, attr := range t.Attr {
 				prefix := ""
@@ -295,7 +321,6 @@ L:
 					continue
 				}
 				attrValues := strings.Split(attr.Val, attrValSep)
-
 				var (
 					// start and end are the byte offsets of one attribute value.
 					// Which are re-calculated on each iteration of the next loop.
@@ -305,10 +330,15 @@ L:
 				for _, val := range attrValues {
 					l := len([]byte(val))
 					end = uint32(start + uint32(l))
+					hrefs := normalizeStylesheetHREFs(stylesheetHREFs, filepath.Dir(filePath))
+					defPath := resolveSelectorDefPath(selectorDefs, selector(prefix+val), hrefs)
+					if defPath == nil { // selector definition not found.
+						continue
+					}
 					refs = append(refs, &graph.Ref{
 						DefUnitType: "basic-css",
 						DefUnit:     u.Name,
-						DefPath:     selectorDefPath(cssFilePath, selector(prefix+val)),
+						DefPath:     *defPath,
 						Unit:        u.Name,
 						File:        filepath.ToSlash(filePath),
 						Start:       start,
@@ -372,4 +402,34 @@ func selectorKind(selectorStr string) string {
 // selectorDefPath returns the def path of the given selector.
 func selectorDefPath(filePath string, s selector) string {
 	return fmt.Sprintf("%s%s", filepath.ToSlash(filePath), string(s))
+}
+
+// resolveSelectorDefPath returns the definition path of given selector(`s`).
+func resolveSelectorDefPath(selectorsDef []*graph.Def, s selector, stylesheetPaths []string) *string {
+	for _, def := range selectorsDef {
+		if def.Name == s.String() && stylesheetPathExists(stylesheetPaths, def.File) {
+			return &def.DefKey.Path
+		}
+	}
+	return nil
+}
+
+// normalizeStylesheetHREFs normalizes each element of given `stylesheetHREFs`
+// to be relative path of given `root`.
+func normalizeStylesheetHREFs(stylesheetHREFs []string, root string) []string {
+	var normalized []string
+	for _, s := range stylesheetHREFs {
+		normalized = append(normalized, filepath.ToSlash(filepath.Join(root, s)))
+	}
+	return normalized
+}
+
+// stylesheetPathExists returns true if given filepath(`fp`) exists on `stylesheetPaths`.
+func stylesheetPathExists(stylesheetsPath []string, fp string) bool {
+	for _, s := range stylesheetsPath {
+		if s == fp {
+			return true
+		}
+	}
+	return false
 }

--- a/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/basic-css.graph.json
+++ b/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/basic-css.graph.json
@@ -3,11 +3,635 @@
     {
       "UnitType": "basic-css",
       "Unit": "css-sample-0",
+      "Path": "alerts.css.alert h4",
+      "Name": ".alert h4",
+      "File": "alerts.css",
+      "DefStart": 106,
+      "DefEnd": 115,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "alerts.css.alert",
+      "Name": ".alert",
+      "File": "alerts.css",
+      "DefStart": 1,
+      "DefEnd": 6,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "alerts.css.alert-danger hr",
+      "Name": ".alert-danger hr",
+      "File": "alerts.css",
+      "DefStart": 1131,
+      "DefEnd": 1147,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "alerts.css.alert-danger",
+      "Name": ".alert-danger",
+      "File": "alerts.css",
+      "DefStart": 1041,
+      "DefEnd": 1054,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "alerts.css.alert-dismissable",
+      "Name": ".alert-dismissable",
+      "File": "alerts.css",
+      "DefStart": 285,
+      "DefEnd": 303,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "alerts.css.alert-dismissible",
+      "Name": ".alert-dismissible",
+      "File": "alerts.css",
+      "DefStart": 305,
+      "DefEnd": 323,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "alerts.css.alert-info hr",
+      "Name": ".alert-info hr",
+      "File": "alerts.css",
+      "DefStart": 756,
+      "DefEnd": 770,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "alerts.css.alert-info",
+      "Name": ".alert-info",
+      "File": "alerts.css",
+      "DefStart": 668,
+      "DefEnd": 679,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "alerts.css.alert-link",
+      "Name": ".alert-link",
+      "File": "alerts.css",
+      "DefStart": 155,
+      "DefEnd": 173,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "alerts.css.alert-success hr",
+      "Name": ".alert-success hr",
+      "File": "alerts.css",
+      "DefStart": 568,
+      "DefEnd": 585,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "alerts.css.alert-success",
+      "Name": ".alert-success",
+      "File": "alerts.css",
+      "DefStart": 477,
+      "DefEnd": 491,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "alerts.css.alert-warning hr",
+      "Name": ".alert-warning hr",
+      "File": "alerts.css",
+      "DefStart": 941,
+      "DefEnd": 958,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "alerts.css.alert-warning",
+      "Name": ".alert-warning",
+      "File": "alerts.css",
+      "DefStart": 850,
+      "DefEnd": 864,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "alerts.css.close",
+      "Name": ".close",
+      "File": "alerts.css",
+      "DefStart": 351,
+      "DefEnd": 376,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.badge",
+      "Name": ".badge",
+      "File": "assets/panels.css",
+      "DefStart": 10294,
+      "DefEnd": 10332,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.dropdown-toggle",
+      "Name": ".dropdown-toggle",
+      "File": "assets/panels.css",
+      "DefStart": 396,
+      "DefEnd": 439,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.list-group",
+      "Name": ".list-group",
+      "File": "assets/panels.css",
+      "DefStart": 858,
+      "DefEnd": 878,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.list-group-item",
+      "Name": ".list-group-item",
+      "File": "assets/panels.css",
+      "DefStart": 943,
+      "DefEnd": 980,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.list-group-item:first-child",
+      "Name": ".list-group-item:first-child",
+      "File": "assets/panels.css",
+      "DefStart": 1085,
+      "DefEnd": 1146,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.list-group-item:last-child",
+      "Name": ".list-group-item:last-child",
+      "File": "assets/panels.css",
+      "DefStart": 1312,
+      "DefEnd": 1371,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.panel",
+      "Name": ".panel",
+      "File": "assets/panels.css",
+      "DefStart": 1,
+      "DefEnd": 6,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.panel-body",
+      "Name": ".panel-body",
+      "File": "assets/panels.css",
+      "DefStart": 219,
+      "DefEnd": 230,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.panel-danger",
+      "Name": ".panel-danger",
+      "File": "assets/panels.css",
+      "DefStart": 12208,
+      "DefEnd": 12221,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.panel-default",
+      "Name": ".panel-default",
+      "File": "assets/panels.css",
+      "DefStart": 10057,
+      "DefEnd": 10071,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.panel-footer",
+      "Name": ".panel-footer",
+      "File": "assets/panels.css",
+      "DefStart": 690,
+      "DefEnd": 703,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.panel-group",
+      "Name": ".panel-group",
+      "File": "assets/panels.css",
+      "DefStart": 9550,
+      "DefEnd": 9562,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.panel-heading",
+      "Name": ".panel-heading",
+      "File": "assets/panels.css",
+      "DefStart": 252,
+      "DefEnd": 266,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.panel-info",
+      "Name": ".panel-info",
+      "File": "assets/panels.css",
+      "DefStart": 11347,
+      "DefEnd": 11358,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.panel-primary",
+      "Name": ".panel-primary",
+      "File": "assets/panels.css",
+      "DefStart": 10477,
+      "DefEnd": 10491,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.panel-success",
+      "Name": ".panel-success",
+      "File": "assets/panels.css",
+      "DefStart": 10909,
+      "DefEnd": 10923,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.panel-title",
+      "Name": ".panel-title",
+      "File": "assets/panels.css",
+      "DefStart": 462,
+      "DefEnd": 474,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.panel-warning",
+      "Name": ".panel-warning",
+      "File": "assets/panels.css",
+      "DefStart": 11770,
+      "DefEnd": 11784,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.small",
+      "Name": ".small",
+      "File": "assets/panels.css",
+      "DefStart": 593,
+      "DefEnd": 614,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.table caption",
+      "Name": ".table caption",
+      "File": "assets/panels.css",
+      "DefStart": 1944,
+      "DefEnd": 1967,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.table",
+      "Name": ".table",
+      "File": "assets/panels.css",
+      "DefStart": 1832,
+      "DefEnd": 1847,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.table-bordered",
+      "Name": ".table-bordered",
+      "File": "assets/panels.css",
+      "DefStart": 6689,
+      "DefEnd": 6713,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.table-responsive",
+      "Name": ".table-responsive",
+      "File": "assets/panels.css",
+      "DefStart": 6407,
+      "DefEnd": 6447,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.table:first-child",
+      "Name": ".table:first-child",
+      "File": "assets/panels.css",
+      "DefStart": 2105,
+      "DefEnd": 2132,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "assets/panels.css.table:last-child",
+      "Name": ".table:last-child",
+      "File": "assets/panels.css",
+      "DefStart": 4268,
+      "DefEnd": 4294,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
       "Path": "main.css#container",
       "Name": "#container",
       "File": "main.css",
-      "DefStart": 89,
-      "DefEnd": 99,
+      "DefStart": 1,
+      "DefEnd": 10,
       "Data": {
         "Name": "",
         "Keyword": "selector",
@@ -22,24 +646,8 @@
       "Path": "main.css.active:focus",
       "Name": ".active:focus",
       "File": "main.css",
-      "DefStart": 800,
-      "DefEnd": 817,
-      "Data": {
-        "Name": "",
-        "Keyword": "selector",
-        "Type": "",
-        "Kind": "class",
-        "Separator": ""
-      }
-    },
-    {
-      "UnitType": "basic-css",
-      "Unit": "css-sample-0",
-      "Path": "main.css.alert-info",
-      "Name": ".alert-info",
-      "File": "main.css",
-      "DefStart": 1,
-      "DefEnd": 11,
+      "DefStart": 672,
+      "DefEnd": 689,
       "Data": {
         "Name": "",
         "Keyword": "selector",
@@ -54,8 +662,8 @@
       "Path": "main.css.btn",
       "Name": ".btn",
       "File": "main.css",
-      "DefStart": 269,
-      "DefEnd": 273,
+      "DefStart": 141,
+      "DefEnd": 145,
       "Data": {
         "Name": "",
         "Keyword": "selector",
@@ -70,8 +678,8 @@
       "Path": "main.css.btn-default",
       "Name": ".btn-default",
       "File": "main.css",
-      "DefStart": 967,
-      "DefEnd": 979,
+      "DefStart": 839,
+      "DefEnd": 851,
       "Data": {
         "Name": "",
         "Keyword": "selector",
@@ -86,8 +694,8 @@
       "Path": "main.css.btn-sm",
       "Name": ".btn-sm",
       "File": "main.css",
-      "DefStart": 1048,
-      "DefEnd": 1055,
+      "DefStart": 920,
+      "DefEnd": 927,
       "Data": {
         "Name": "",
         "Keyword": "selector",
@@ -102,8 +710,8 @@
       "Path": "main.css.btn:active:focus",
       "Name": ".btn:active:focus",
       "File": "main.css",
-      "DefStart": 781,
-      "DefEnd": 798,
+      "DefStart": 653,
+      "DefEnd": 670,
       "Data": {
         "Name": "",
         "Keyword": "selector",
@@ -118,8 +726,8 @@
       "Path": "main.css.btn:focus",
       "Name": ".btn:focus",
       "File": "main.css",
-      "DefStart": 769,
-      "DefEnd": 779,
+      "DefStart": 641,
+      "DefEnd": 651,
       "Data": {
         "Name": "",
         "Keyword": "selector",
@@ -134,8 +742,8 @@
       "Path": "main.css.container-inner",
       "Name": ".container-inner",
       "File": "main.css",
-      "DefStart": 172,
-      "DefEnd": 201,
+      "DefStart": 83,
+      "DefEnd": 112,
       "Data": {
         "Name": "",
         "Keyword": "selector",
@@ -150,8 +758,8 @@
       "Path": "main.css.focus",
       "Name": ".focus",
       "File": "main.css",
-      "DefStart": 819,
-      "DefEnd": 829,
+      "DefStart": 691,
+      "DefEnd": 701,
       "Data": {
         "Name": "",
         "Keyword": "selector",
@@ -163,16 +771,48 @@
     {
       "UnitType": "basic-css",
       "Unit": "css-sample-0",
-      "Path": "main.css.paragraph",
-      "Name": ".paragraph",
-      "File": "main.css",
-      "DefStart": 230,
-      "DefEnd": 241,
+      "Path": "not-used.css.not-used",
+      "Name": ".not-used",
+      "File": "not-used.css",
+      "DefStart": 1,
+      "DefEnd": 9,
       "Data": {
         "Name": "",
         "Keyword": "selector",
         "Type": "",
         "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "querystringed.css.paragraph",
+      "Name": ".paragraph",
+      "File": "querystringed.css",
+      "DefStart": 1,
+      "DefEnd": 11,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "class",
+        "Separator": ""
+      }
+    },
+    {
+      "UnitType": "basic-css",
+      "Unit": "css-sample-0",
+      "Path": "subdir/assets/main.css#container",
+      "Name": "#container",
+      "File": "subdir/assets/main.css",
+      "DefStart": 1,
+      "DefEnd": 10,
+      "Data": {
+        "Name": "",
+        "Keyword": "selector",
+        "Type": "",
+        "Kind": "id",
         "Separator": ""
       }
     }
@@ -181,108 +821,225 @@
     {
       "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
-      "DefPath": "#container",
+      "DefPath": "alerts.css.alert-info",
       "Unit": "css-sample-0",
       "File": "main.html",
-      "Start": 174,
-      "End": 183
+      "Start": 1099,
+      "End": 1109
     },
     {
       "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
-      "DefPath": ".alert-info",
+      "DefPath": "alerts.css.alert-info",
       "Unit": "css-sample-0",
       "File": "main.html",
-      "Start": 271,
-      "End": 281
+      "Start": 902,
+      "End": 912
     },
     {
       "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
-      "DefPath": ".alert-info",
+      "DefPath": "assets/panels.css.panel-body",
       "Unit": "css-sample-0",
       "File": "main.html",
-      "Start": 413,
-      "End": 423
+      "Start": 1463,
+      "End": 1473
     },
     {
       "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
-      "DefPath": ".btn-default",
+      "DefPath": "assets/panels.css.panel-body",
       "Unit": "css-sample-0",
-      "File": "main.html",
-      "Start": 461,
-      "End": 472
+      "File": "subdir/assets/main.html",
+      "Start": 552,
+      "End": 562
     },
     {
       "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
-      "DefPath": ".btn-default",
+      "DefPath": "assets/panels.css.panel-default",
       "Unit": "css-sample-0",
       "File": "main.html",
-      "Start": 553,
-      "End": 564
+      "Start": 1421,
+      "End": 1434
     },
     {
       "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
-      "DefPath": ".btn-sm",
+      "DefPath": "assets/panels.css.panel-default",
       "Unit": "css-sample-0",
-      "File": "main.html",
-      "Start": 565,
-      "End": 571
+      "File": "subdir/assets/main.html",
+      "Start": 514,
+      "End": 527
     },
     {
       "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
-      "DefPath": ".btn",
+      "DefPath": "assets/panels.css.panel",
       "Unit": "css-sample-0",
       "File": "main.html",
-      "Start": 457,
-      "End": 460
+      "Start": 1415,
+      "End": 1420
     },
     {
       "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
-      "DefPath": ".btn",
+      "DefPath": "assets/panels.css.panel",
       "Unit": "css-sample-0",
-      "File": "main.html",
-      "Start": 549,
-      "End": 552
-    },
-    {
-      "DefUnitType": "basic-css",
-      "DefUnit": "css-sample-0",
-      "DefPath": ".container-inner",
-      "Unit": "css-sample-0",
-      "File": "main.html",
-      "Start": 210,
-      "End": 225
-    },
-    {
-      "DefUnitType": "basic-css",
-      "DefUnit": "css-sample-0",
-      "DefPath": ".paragraph",
-      "Unit": "css-sample-0",
-      "File": "main.html",
-      "Start": 325,
-      "End": 334
-    },
-    {
-      "DefUnitType": "basic-css",
-      "DefUnit": "css-sample-0",
-      "DefPath": ".paragraph",
-      "Unit": "css-sample-0",
-      "File": "main.html",
-      "Start": 376,
-      "End": 385
+      "File": "subdir/assets/main.html",
+      "Start": 508,
+      "End": 513
     },
     {
       "DefUnitType": "URL",
       "DefUnit": "MDN",
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
       "Unit": "css-sample-0",
-      "File": "main.css",
+      "File": "alerts.css",
+      "Start": 1077,
+      "End": 1093
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 514,
+      "End": 530
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 702,
+      "End": 718
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 887,
+      "End": 903
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10149,
+      "End": 10165
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10355,
+      "End": 10371
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10572,
+      "End": 10588
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10784,
+      "End": 10800
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11007,
+      "End": 11023
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11219,
+      "End": 11235
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11439,
+      "End": 11455
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11645,
+      "End": 11661
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11868,
+      "End": 11884
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 12080,
+      "End": 12096
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 12304,
+      "End": 12320
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 12514,
+      "End": 12530
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
       "Start": 34,
       "End": 50
     },
@@ -291,9 +1048,18 @@
       "DefUnit": "MDN",
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
       "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 730,
+      "End": 746
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-color",
+      "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 999,
-      "End": 1015
+      "Start": 871,
+      "End": 887
     },
     {
       "DefUnitType": "URL",
@@ -301,8 +1067,350 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/background-image",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 687,
-      "End": 703
+      "Start": 559,
+      "End": 575
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10448,
+      "End": 10467
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10877,
+      "End": 10896
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11315,
+      "End": 11334
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11738,
+      "End": 11757
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 12176,
+      "End": 12195
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 12609,
+      "End": 12628
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 1510,
+      "End": 1535
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 4393,
+      "End": 4418
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 4779,
+      "End": 4804
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 5564,
+      "End": 5589
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 824,
+      "End": 849
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 1475,
+      "End": 1501
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 4358,
+      "End": 4384
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 4744,
+      "End": 4770
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 6341,
+      "End": 6367
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 789,
+      "End": 815
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10024,
+      "End": 10037
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 1455,
+      "End": 1468
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 293,
+      "End": 306
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 8923,
+      "End": 8936
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 9466,
+      "End": 9479
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 9740,
+      "End": 9753
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 1106,
+      "End": 1118
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 543,
+      "End": 555
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 731,
+      "End": 743
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 916,
+      "End": 928
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10076,
+      "End": 10088
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10178,
+      "End": 10190
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10496,
+      "End": 10508
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10601,
+      "End": 10613
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10928,
+      "End": 10940
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11036,
+      "End": 11048
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11363,
+      "End": 11375
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11468,
+      "End": 11480
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11789,
+      "End": 11801
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11897,
+      "End": 11909
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 12226,
+      "End": 12238
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 12333,
+      "End": 12345
     },
     {
       "DefUnitType": "URL",
@@ -310,17 +1418,53 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 1025,
-      "End": 1037
+      "Start": 897,
+      "End": 909
     },
     {
       "DefUnitType": "URL",
       "DefUnit": "MDN",
-      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-color",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-left",
       "Unit": "css-sample-0",
-      "File": "main.css",
-      "Start": 63,
-      "End": 75
+      "File": "assets/panels.css",
+      "Start": 7572,
+      "End": 7583
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 84,
+      "End": 97
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 1065,
+      "End": 1078
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 93,
+      "End": 106
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 9634,
+      "End": 9647
     },
     {
       "DefUnitType": "URL",
@@ -328,8 +1472,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 1142,
-      "End": 1155
+      "Start": 1014,
+      "End": 1027
     },
     {
       "DefUnitType": "URL",
@@ -337,8 +1481,332 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 746,
-      "End": 759
+      "Start": 618,
+      "End": 631
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-right",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 8373,
+      "End": 8385
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 1152,
+      "End": 1168
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 590,
+      "End": 606
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 775,
+      "End": 791
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 963,
+      "End": 979
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10268,
+      "End": 10284
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10694,
+      "End": 10710
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11129,
+      "End": 11145
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11558,
+      "End": 11574
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11990,
+      "End": 12006
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 12425,
+      "End": 12441
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 1249,
+      "End": 1271
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 1633,
+      "End": 1655
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 2198,
+      "End": 2220
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 2592,
+      "End": 2614
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 333,
+      "End": 355
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 3434,
+      "End": 3456
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 1280,
+      "End": 1303
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 1662,
+      "End": 1685
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 2229,
+      "End": 2252
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 2623,
+      "End": 2646
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 364,
+      "End": 387
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 4236,
+      "End": 4259
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 1754,
+      "End": 1770
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 1809,
+      "End": 1825
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 1232,
+      "End": 1242
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 6525,
+      "End": 6535
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 6672,
+      "End": 6682
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 759,
+      "End": 769
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 9885,
+      "End": 9895
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-top",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 9946,
+      "End": 9956
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-width",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 1042,
+      "End": 1054
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 51,
+      "End": 57
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 60,
+      "End": 66
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 6764,
+      "End": 6770
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 9537,
+      "End": 9543
     },
     {
       "DefUnitType": "URL",
@@ -346,8 +1814,251 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/border",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 713,
-      "End": 719
+      "Start": 585,
+      "End": 591
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 115,
+      "End": 133
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 175,
+      "End": 185
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 1023,
+      "End": 1028
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 1059,
+      "End": 1064
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 1211,
+      "End": 1216
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 137,
+      "End": 142
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 459,
+      "End": 464
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 496,
+      "End": 501
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 650,
+      "End": 655
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 684,
+      "End": 689
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 832,
+      "End": 837
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 869,
+      "End": 874
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10134,
+      "End": 10139
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10337,
+      "End": 10342
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10557,
+      "End": 10562
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10766,
+      "End": 10771
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 10989,
+      "End": 10994
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11201,
+      "End": 11206
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11421,
+      "End": 11426
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11627,
+      "End": 11632
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11850,
+      "End": 11855
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 12062,
+      "End": 12067
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 12286,
+      "End": 12291
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 12496,
+      "End": 12501
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 444,
+      "End": 449
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 535,
+      "End": 540
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 672,
+      "End": 677
     },
     {
       "DefUnitType": "URL",
@@ -355,17 +2066,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 16,
-      "End": 21
-    },
-    {
-      "DefUnitType": "URL",
-      "DefUnit": "MDN",
-      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/color",
-      "Unit": "css-sample-0",
-      "File": "main.css",
-      "Start": 984,
-      "End": 989
+      "Start": 856,
+      "End": 861
     },
     {
       "DefUnitType": "URL",
@@ -373,8 +2075,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/cursor",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 552,
-      "End": 558
+      "Start": 424,
+      "End": 430
     },
     {
       "DefUnitType": "URL",
@@ -382,8 +2084,17 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/display",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 278,
-      "End": 285
+      "Start": 150,
+      "End": 157
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/font-size",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 516,
+      "End": 525
     },
     {
       "DefUnitType": "URL",
@@ -391,8 +2102,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/font-size",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 1103,
-      "End": 1112
+      "Start": 216,
+      "End": 225
     },
     {
       "DefUnitType": "URL",
@@ -400,8 +2111,17 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/font-size",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 344,
-      "End": 353
+      "Start": 975,
+      "End": 984
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 178,
+      "End": 189
     },
     {
       "DefUnitType": "URL",
@@ -409,8 +2129,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 363,
-      "End": 374
+      "Start": 235,
+      "End": 246
     },
     {
       "DefUnitType": "URL",
@@ -418,8 +2138,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/line-height",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 1122,
-      "End": 1133
+      "Start": 258,
+      "End": 269
     },
     {
       "DefUnitType": "URL",
@@ -427,8 +2147,89 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/line-height",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 386,
-      "End": 397
+      "Start": 994,
+      "End": 1005
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 227,
+      "End": 240
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 28,
+      "End": 41
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 11,
+      "End": 24
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 1924,
+      "End": 1937
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 496,
+      "End": 509
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 923,
+      "End": 936
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 9517,
+      "End": 9530
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 9567,
+      "End": 9580
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 9614,
+      "End": 9627
     },
     {
       "DefUnitType": "URL",
@@ -436,8 +2237,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 324,
-      "End": 337
+      "Start": 196,
+      "End": 209
     },
     {
       "DefUnitType": "URL",
@@ -445,8 +2246,53 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-right",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 149,
-      "End": 161
+      "Start": 60,
+      "End": 72
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-top",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 120,
+      "End": 130
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-top",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 266,
+      "End": 276
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-top",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 479,
+      "End": 489
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin-top",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 9689,
+      "End": 9699
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/margin",
+      "Unit": "css-sample-0",
+      "File": "not-used.css",
+      "Start": 16,
+      "End": 22
     },
     {
       "DefUnitType": "URL",
@@ -454,8 +2300,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/outline-offset",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 942,
-      "End": 956
+      "Start": 814,
+      "End": 828
     },
     {
       "DefUnitType": "URL",
@@ -463,8 +2309,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/outline",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 872,
-      "End": 879
+      "Start": 744,
+      "End": 751
     },
     {
       "DefUnitType": "URL",
@@ -472,8 +2318,17 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/outline",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 896,
-      "End": 903
+      "Start": 768,
+      "End": 775
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding-left",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 2083,
+      "End": 2095
     },
     {
       "DefUnitType": "URL",
@@ -481,17 +2336,44 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding-left",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 127,
-      "End": 139
+      "Start": 38,
+      "End": 50
     },
     {
       "DefUnitType": "URL",
       "DefUnit": "MDN",
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding-left",
       "Unit": "css-sample-0",
-      "File": "main.css",
-      "Start": 246,
-      "End": 258
+      "File": "querystringed.css",
+      "Start": 16,
+      "End": 28
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding-left",
+      "Unit": "css-sample-0",
+      "File": "subdir/assets/main.css",
+      "Start": 38,
+      "End": 50
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding-right",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 328,
+      "End": 341
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding-right",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 2060,
+      "End": 2073
     },
     {
       "DefUnitType": "URL",
@@ -499,8 +2381,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding-right",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 104,
-      "End": 117
+      "Start": 117,
+      "End": 130
     },
     {
       "DefUnitType": "URL",
@@ -508,8 +2390,53 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding-right",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 206,
-      "End": 219
+      "Start": 15,
+      "End": 28
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding-right",
+      "Unit": "css-sample-0",
+      "File": "subdir/assets/main.css",
+      "Start": 15,
+      "End": 28
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 11,
+      "End": 18
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 235,
+      "End": 242
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 271,
+      "End": 278
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding",
+      "Unit": "css-sample-0",
+      "File": "assets/panels.css",
+      "Start": 708,
+      "End": 715
     },
     {
       "DefUnitType": "URL",
@@ -517,8 +2444,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 1082,
-      "End": 1089
+      "Start": 175,
+      "End": 182
     },
     {
       "DefUnitType": "URL",
@@ -526,8 +2453,26 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/padding",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 303,
-      "End": 310
+      "Start": 954,
+      "End": 961
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/position",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 408,
+      "End": 416
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/right",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 443,
+      "End": 448
     },
     {
       "DefUnitType": "URL",
@@ -535,8 +2480,17 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/text-align",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 413,
-      "End": 423
+      "Start": 285,
+      "End": 295
+    },
+    {
+      "DefUnitType": "URL",
+      "DefUnit": "MDN",
+      "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/top",
+      "Unit": "css-sample-0",
+      "File": "alerts.css",
+      "Start": 430,
+      "End": 433
     },
     {
       "DefUnitType": "URL",
@@ -544,8 +2498,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 484,
-      "End": 500
+      "Start": 356,
+      "End": 372
     },
     {
       "DefUnitType": "URL",
@@ -553,8 +2507,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 522,
-      "End": 534
+      "Start": 394,
+      "End": 406
     },
     {
       "DefUnitType": "URL",
@@ -562,8 +2516,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/user-select",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 571,
-      "End": 590
+      "Start": 443,
+      "End": 462
     },
     {
       "DefUnitType": "URL",
@@ -571,8 +2525,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/user-select",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 603,
-      "End": 619
+      "Start": 475,
+      "End": 491
     },
     {
       "DefUnitType": "URL",
@@ -580,8 +2534,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/user-select",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 633,
-      "End": 648
+      "Start": 505,
+      "End": 520
     },
     {
       "DefUnitType": "URL",
@@ -589,8 +2543,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/user-select",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 666,
-      "End": 677
+      "Start": 538,
+      "End": 549
     },
     {
       "DefUnitType": "URL",
@@ -598,8 +2552,8 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 458,
-      "End": 472
+      "Start": 330,
+      "End": 344
     },
     {
       "DefUnitType": "URL",
@@ -607,8 +2561,89 @@
       "DefPath": "https://developer.mozilla.org/en-US/docs/Web/CSS/white-space",
       "Unit": "css-sample-0",
       "File": "main.css",
-      "Start": 435,
-      "End": 446
+      "Start": 307,
+      "End": 318
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css#container",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 818,
+      "End": 827
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.btn-default",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 1147,
+      "End": 1158
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.btn-default",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 1239,
+      "End": 1250
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.btn-sm",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 1251,
+      "End": 1257
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.btn",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 1143,
+      "End": 1146
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.btn",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 1235,
+      "End": 1238
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.container-inner",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 1587,
+      "End": 1602
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.container-inner",
+      "Unit": "css-sample-0",
+      "File": "main.html",
+      "Start": 854,
+      "End": 869
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "subdir/assets/main.css#container",
+      "Unit": "css-sample-0",
+      "File": "subdir/assets/main.html",
+      "Start": 431,
+      "End": 440
     }
   ]
 }

--- a/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/basic-css.graph.json
+++ b/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/basic-css.graph.json
@@ -821,6 +821,76 @@
     {
       "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.alert h4",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 106,
+      "End": 115
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.alert-danger hr",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 1131,
+      "End": 1147
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.alert-danger",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 1041,
+      "End": 1054
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.alert-dismissable",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 285,
+      "End": 303
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.alert-dismissible",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 305,
+      "End": 323
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.alert-info hr",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 756,
+      "End": 770
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.alert-info",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 668,
+      "End": 679
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
       "DefPath": "alerts.css.alert-info",
       "Unit": "css-sample-0",
       "File": "main.html",
@@ -835,6 +905,146 @@
       "File": "main.html",
       "Start": 902,
       "End": 912
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.alert-link",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 155,
+      "End": 173
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.alert-success hr",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 568,
+      "End": 585
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.alert-success",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 477,
+      "End": 491
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.alert-warning hr",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 941,
+      "End": 958
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.alert-warning",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 850,
+      "End": 864
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.alert",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 1,
+      "End": 6
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "alerts.css.close",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "alerts.css",
+      "Start": 351,
+      "End": 376
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.badge",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 10294,
+      "End": 10332
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.dropdown-toggle",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 396,
+      "End": 439
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.list-group-item:first-child",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 1085,
+      "End": 1146
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.list-group-item:last-child",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 1312,
+      "End": 1371
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.list-group-item",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 943,
+      "End": 980
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.list-group",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 858,
+      "End": 878
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.panel-body",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 219,
+      "End": 230
     },
     {
       "DefUnitType": "basic-css",
@@ -857,6 +1067,26 @@
     {
       "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.panel-danger",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 12208,
+      "End": 12221
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.panel-default",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 10057,
+      "End": 10071
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
       "DefPath": "assets/panels.css.panel-default",
       "Unit": "css-sample-0",
       "File": "main.html",
@@ -875,6 +1105,96 @@
     {
       "DefUnitType": "basic-css",
       "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.panel-footer",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 690,
+      "End": 703
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.panel-group",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 9550,
+      "End": 9562
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.panel-heading",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 252,
+      "End": 266
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.panel-info",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 11347,
+      "End": 11358
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.panel-primary",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 10477,
+      "End": 10491
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.panel-success",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 10909,
+      "End": 10923
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.panel-title",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 462,
+      "End": 474
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.panel-warning",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 11770,
+      "End": 11784
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.panel",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 1,
+      "End": 6
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
       "DefPath": "assets/panels.css.panel",
       "Unit": "css-sample-0",
       "File": "main.html",
@@ -889,6 +1209,76 @@
       "File": "subdir/assets/main.html",
       "Start": 508,
       "End": 513
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.small",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 593,
+      "End": 614
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.table caption",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 1944,
+      "End": 1967
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.table-bordered",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 6689,
+      "End": 6713
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.table-responsive",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 6407,
+      "End": 6447
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.table:first-child",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 2105,
+      "End": 2132
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.table:last-child",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 4268,
+      "End": 4294
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "assets/panels.css.table",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "assets/panels.css",
+      "Start": 1832,
+      "End": 1847
     },
     {
       "DefUnitType": "URL",
@@ -2569,9 +2959,39 @@
       "DefUnit": "css-sample-0",
       "DefPath": "main.css#container",
       "Unit": "css-sample-0",
+      "Def": true,
+      "File": "main.css",
+      "Start": 1,
+      "End": 10
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css#container",
+      "Unit": "css-sample-0",
       "File": "main.html",
       "Start": 818,
       "End": 827
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.active:focus",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "main.css",
+      "Start": 672,
+      "End": 689
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.btn-default",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "main.css",
+      "Start": 839,
+      "End": 851
     },
     {
       "DefUnitType": "basic-css",
@@ -2596,9 +3016,49 @@
       "DefUnit": "css-sample-0",
       "DefPath": "main.css.btn-sm",
       "Unit": "css-sample-0",
+      "Def": true,
+      "File": "main.css",
+      "Start": 920,
+      "End": 927
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.btn-sm",
+      "Unit": "css-sample-0",
       "File": "main.html",
       "Start": 1251,
       "End": 1257
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.btn:active:focus",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "main.css",
+      "Start": 653,
+      "End": 670
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.btn:focus",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "main.css",
+      "Start": 641,
+      "End": 651
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.btn",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "main.css",
+      "Start": 141,
+      "End": 145
     },
     {
       "DefUnitType": "basic-css",
@@ -2623,6 +3083,16 @@
       "DefUnit": "css-sample-0",
       "DefPath": "main.css.container-inner",
       "Unit": "css-sample-0",
+      "Def": true,
+      "File": "main.css",
+      "Start": 83,
+      "End": 112
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.container-inner",
+      "Unit": "css-sample-0",
       "File": "main.html",
       "Start": 1587,
       "End": 1602
@@ -2635,6 +3105,46 @@
       "File": "main.html",
       "Start": 854,
       "End": 869
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "main.css.focus",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "main.css",
+      "Start": 691,
+      "End": 701
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "not-used.css.not-used",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "not-used.css",
+      "Start": 1,
+      "End": 9
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "querystringed.css.paragraph",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "querystringed.css",
+      "Start": 1,
+      "End": 11
+    },
+    {
+      "DefUnitType": "basic-css",
+      "DefUnit": "css-sample-0",
+      "DefPath": "subdir/assets/main.css#container",
+      "Unit": "css-sample-0",
+      "Def": true,
+      "File": "subdir/assets/main.css",
+      "Start": 1,
+      "End": 10
     },
     {
       "DefUnitType": "basic-css",

--- a/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/basic-css.unit.json
+++ b/testdata/expected/src/github.com/sgtest/css-sample-0/css-sample-0/basic-css.unit.json
@@ -1,1 +1,1 @@
-{"Name":"css-sample-0","Type":"basic-css","Files":["main.css","main.html"],"Dir":"."}
+{"Name":"css-sample-0","Type":"basic-css","Files":["alerts.css","assets/panels.css","broken.css","main.css","main.html","not-used.css","querystringed.css","subdir/assets/main.css","subdir/assets/main.html"],"Dir":"."}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -5,14 +5,14 @@
 		{
 			"checksumSHA1": "ulHAt7P7SYMC2g3ThlXNzVN9Z/k=",
 			"path": "github.com/chris-ramon/douceur/css",
-			"revision": "8fb95984c34738e277513d254dfa4e6bfc39f29a",
-			"revisionTime": "2016-05-31T16:43:54Z"
+			"revision": "f3463056cd52886eda904655e1940157bf323bd7",
+			"revisionTime": "2016-06-03T23:54:19Z"
 		},
 		{
-			"checksumSHA1": "RbWaDh535llZY3nt+Rl6LI8WOis=",
+			"checksumSHA1": "jWIgyVGWXtHIKfRy40IUlMZyvUY=",
 			"path": "github.com/chris-ramon/douceur/parser",
-			"revision": "8fb95984c34738e277513d254dfa4e6bfc39f29a",
-			"revisionTime": "2016-05-31T16:43:54Z"
+			"revision": "f3463056cd52886eda904655e1940157bf323bd7",
+			"revisionTime": "2016-06-03T23:54:19Z"
 		},
 		{
 			"checksumSHA1": "lxT9A/L1DNHXpPDsEUsS3R6JS34=",


### PR DESCRIPTION
##### Description
- Built on top of: https://github.com/sourcegraph/srclib-css/pull/17
- Relevant commit: https://github.com/sourcegraph/srclib-css/pull/18/commits/592c56acb7bf67fca6775d68ecb7084d82ba6acc - the other commits are from #17 
- Grapher: Emits CSS selector refs.
- testdata: Updates to reflect new CSS selector refs.
- code clean-up, renames:
  - `cssDefs` -> `cssDefsAndRefs`
  - `cssRefs` -> `mdnCSSRefs`
